### PR TITLE
Problem: Selftest doesn't respect verbose parameter.

### DIFF
--- a/src/fty_outage_server.c
+++ b/src/fty_outage_server.c
@@ -501,6 +501,8 @@ fty_outage_server_test (bool verbose)
 {
     printf (" * fty_outage_server: \n");
     ftylog_setInstance("fty_outage_server_test","");
+    if (verbose)
+        ftylog_setVeboseMode(ftylog_getInstance());
     //     @selftest
     static const char *endpoint =  "inproc://malamute-test2";
 


### PR DESCRIPTION
Solution: Make it do so.

Signed-off-by: Jana Rapava <janarapava@eaton.com>