### PR TITLE
Problem: Inappropriate alarms during FW upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ State file for fty-outage is stored in /var/lib/fty/fty-outage.zpl.
 
 ### Overview
 
-fty-outage is composed of 1 actor and 2 timera.
+fty-outage is composed of 1 actor and 2 timers.
 
 * fty-outage-server: main actor
 
@@ -63,7 +63,46 @@ Agent publishes alerts on \_ALERTS\_SYS stream.
 
 ### Mailbox requests
 
-Agent fty-outage-server doesn't support any mailbox requests.
+It is possible to request the agent fty-outage for:
+
+* putting devices into or returning devices from maintenance mode: this is used
+to temporarily ignore outages on assets that are known to not be currently
+serving data (for example, due to a FW upgrade).
+
+#### Putting devices into or returning devices from maintenance mode
+
+The USER peer sends the following messages using MAILBOX SEND to
+FTY-OUTAGE-AGENT ("fty-outage") peer:
+
+* REQUEST/'correlation\_ID'/MAINTENANCE_MODE/<mode>/asset1/.../assetN/expiration_ttl - switch 'asset1' to 'assetN' into maintenance
+
+where
+* '/' indicates a multipart string message
+* 'correlation\_ID' is a zuuid identifier provided by the caller
+* <mode> MUST be 'enable' or 'disable'
+* 'asset1', ..., 'assetN' MUST be the device(s) asset name
+* 'expiration_ttl' (optional) is an amount of seconds after which the asset(s)
+will be automatically returned from maintenance mode. If 'expiration_ttl' is not
+provided, the default value ('maintenance_expiration') will be used from agent
+configuration file
+* subject of the message is discarded
+
+The FTY-OUTAGE-AGENT peer MUST respond with one of the messages back to USER
+peer using MAILBOX SEND.
+
+* REPLY/correlation\_ID/OK
+* REPLY/correlation\_ID/ERROR/reason
+
+where
+* '/' indicates a multipart frame message
+* 'correlation ID' is a zuuid identifier provided by the caller
+* 'reason' is string detailing reason for error. Possible values are:
+  * Invalid command,
+  * Invalid message type,
+  * Command failed,
+  * Missing maintenance mode,
+  * Unsupported maintenance mode.
+
 
 ### Stream subscriptions
 

--- a/include/fty_outage.h
+++ b/include/fty_outage.h
@@ -26,5 +26,10 @@
 #include "fty_outage_library.h"
 
 //  Add your own public definitions here, if you need them
+// Default TTL of assets in maintenance mode
+#define DEFAULT_MAINTENANCE_EXPIRATION  "3600"
+
+#define DISABLE_MAINTENANCE 0
+#define ENABLE_MAINTENANCE  1
 
 #endif

--- a/src/data.cc
+++ b/src/data.cc
@@ -28,18 +28,7 @@
 
 #include "fty_outage_classes.h"
 
-// it is used as TTL, but in formula we are waiting for ttl*2 ->
-// so if we here would have 15 minutes-> the first alert will come in 30 minutes
-#define DEFAULT_ASSET_EXPIRATION_TIME_SEC 15*60/2
-
-//  Structure of our class
-typedef struct _expiration_t {
-    uint64_t ttl_sec;                      // [s] minimal ttl seen for some asset
-    uint64_t last_time_seen_sec;           // [s] time when  some metrics were seen for this asset
-    fty_proto_t *msg;                      // asset represetation
-} expiration_t;
-
-static expiration_t*
+expiration_t*
 expiration_new (uint64_t default_expiry_sec, fty_proto_t **msg_p)
 {
     assert (msg_p);
@@ -52,7 +41,7 @@ expiration_new (uint64_t default_expiry_sec, fty_proto_t **msg_p)
     return self;
 }
 
-static void
+void
 expiration_destroy (expiration_t **self_p)
 {
     assert (self_p);
@@ -66,7 +55,7 @@ expiration_destroy (expiration_t **self_p)
 
 // set up new expected expiration time, given last seen time
 // this function can only prolong exiration_time
-static void
+void
 expiration_update (expiration_t *self, uint64_t new_time_seen_sec)
 {
     assert (self);
@@ -79,7 +68,7 @@ expiration_update (expiration_t *self, uint64_t new_time_seen_sec)
         self->last_time_seen_sec = new_time_seen_sec;
 }
 
-static void
+void
 expiration_update_ttl (expiration_t *self, uint64_t proposed_ttl)
 {
     assert (self);
@@ -92,18 +81,12 @@ expiration_update_ttl (expiration_t *self, uint64_t proposed_ttl)
     }
 }
 
-static uint64_t
+uint64_t
 expiration_get (expiration_t *self)
 {
     assert (self);
     return self->last_time_seen_sec + self->ttl_sec * 2;
 }
-
-struct _data_t {
-    zhashx_t *assets;           // asset_name => expiration time [s]
-    zhashx_t *asset_enames;      // asset iname => asset ename (unicode name)
-    uint64_t default_expiry_sec; // [s] default time for the asset, in what asset would be considered as not responding
-};
 
 //  --------------------------------------------------------------------------
 //  Destroy the data
@@ -308,7 +291,7 @@ data_get_dead (data_t *self)
     log_debug ("now=%" PRIu64 "s", now_sec);
     for (expiration_t *e =  (expiration_t *) zhashx_first (self->assets);
         e != NULL;
-	    e = (expiration_t *) zhashx_next (self->assets))
+        e = (expiration_t *) zhashx_next (self->assets))
     {
         void *asset_name = (void*) zhashx_cursor(self->assets);
         log_debug ("asset: name=%s, ttl=%" PRIu64 ", expires_at=%" PRIu64, asset_name, e->ttl_sec, expiration_get (e));

--- a/src/data.h
+++ b/src/data.h
@@ -24,9 +24,20 @@
 
 #include "../include/fty_outage.h"
 
+// it is used as TTL, but in formula we are waiting for ttl*2 ->
+// so if we here would have 15 minutes-> the first alert will come in 30 minutes
+#define DEFAULT_ASSET_EXPIRATION_TIME_SEC 15*60/2
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+//  Structure of our class
+struct _data_t {
+    zhashx_t *assets;            // asset_name => expiration time [s]
+    zhashx_t *asset_enames;      // asset iname => asset ename (unicode name)
+    uint64_t default_expiry_sec; // [s] default time for the asset, in what asset would be considered as not responding
+};
 
 #ifndef DATA_T_DEFINED
 typedef struct _data_t data_t;
@@ -76,6 +87,33 @@ FTY_OUTAGE_EXPORT int
 //  Self test of this class
 FTY_OUTAGE_EXPORT void
     data_test (bool verbose);
+
+//  Structure of our class
+typedef struct _expiration_t {
+    uint64_t ttl_sec;                      // [s] minimal ttl seen for some asset
+    uint64_t last_time_seen_sec;           // [s] time when  some metrics were seen for this asset
+    fty_proto_t *msg;                      // asset representation
+} expiration_t;
+
+//  Create a new expiration
+FTY_OUTAGE_EXPORT expiration_t*
+expiration_new (uint64_t default_expiry_sec, fty_proto_t **msg_p);
+
+//  Destroy the expiration
+FTY_OUTAGE_EXPORT void
+expiration_destroy (expiration_t **self_p);
+
+//  Update the expiration
+FTY_OUTAGE_EXPORT void
+expiration_update (expiration_t *self, uint64_t new_time_seen_sec);
+
+//  Update the expiration TTL
+FTY_OUTAGE_EXPORT void
+expiration_update_ttl (expiration_t *self, uint64_t proposed_ttl);
+
+//  Get the expiration TTL
+FTY_OUTAGE_EXPORT uint64_t
+expiration_get (expiration_t *self);
 
 //  @end
 

--- a/src/fty-outage.cfg.in
+++ b/src/fty-outage.cfg.in
@@ -5,5 +5,8 @@ server
     background = 0      #   Run as background process
     workdir = .         #   Working directory for daemon
     verbose = 0         #   Do verbose logging of activity?
+    # Assets will be automatically returned from maintenance mode after this
+    # amount of time (in seconds), if not specified otherwise
+    maintenance_expiration = 3600
 log
     config = "/etc/fty/ftylog.cfg"         #   Path to the log configuration file (optional)


### PR DESCRIPTION
Solution: Implement a local maintenance mode
This is used to temporarily ignore outages on assets that are known to not be
currently serving data (for example, due to a FW upgrade)

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>