### PR TITLE
debian/control : remove libzmq3-dev dep.

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -25,7 +25,6 @@ Standards-Version: 4.0.1.0
 Build-Depends: debhelper (>= 9),
     cmake (>=3.0),
     fty-cmake-dev,
-    libzmq3-dev,
     libczmq-dev (>= 3.0.2),
     libmlm-dev (>= 1.0.0),
     libfty-common-logging-dev,


### PR DESCRIPTION
Removed libzmq3-dev from Build-Depends.